### PR TITLE
tcpdump on shaper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,34 @@ services:
     extra_hosts:
       - "server:193.167.100.100"
 
+  tcpdump_leftnet:
+    image: kaazing/tcpdump
+    container_name: vegvisir_tcpdump_leftnet
+    stdin_open: true
+    tty: true
+    depends_on:
+      - sim
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - $LOG_PATH_SHAPER:/logs/
+    network_mode: "container:sim"
+    command: ["-v", "--interface", "eth0", "--packet-buffered", "-w", "/logs/tcpdump_leftnet.pcap" ]
+
+  tcpdump_rightnet:
+    image: kaazing/tcpdump
+    container_name: vegvisir_tcpdump_rightnet
+    stdin_open: true
+    tty: true
+    depends_on:
+      - sim
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - $LOG_PATH_SHAPER:/logs/
+    network_mode: "container:sim"
+    command: ["-v", "--interface", "eth1", "--packet-buffered", "-w", "/logs/tcpdump_rightnet.pcap" ]
+
   server:
     image: $SERVER
     container_name: server

--- a/vegvisir/runner.py
+++ b/vegvisir/runner.py
@@ -201,7 +201,7 @@ class Experiment:
 						# params += " ".join(shaper.additional_envs())
 						# params += " ".join(server.additional_envs())
 						# containers = "sim server " + " ".join(testcase.additional_containers())
-						containers = "sim server"
+						containers = "sim server tcpdump_leftnet tcpdump_rightnet"
 
 						cmd = (
 							docker_compose_vars
@@ -296,9 +296,16 @@ class Experiment:
 						_, out, err = self.host_interface.spawn_blocking_subprocess(docker_compose_vars + " docker compose logs --timestamps client", False, True)
 						self.logger.debug(out)
 						self.logger.debug(err)
+						_, out, err = self.host_interface.spawn_blocking_subprocess(docker_compose_vars + " docker compose logs --timestamps tcpdump_leftnet", False, True)
+						self.logger.debug(out)
+						self.logger.debug(err)
+						_, out, err = self.host_interface.spawn_blocking_subprocess(docker_compose_vars + " docker compose logs --timestamps tcpdump_rightnet", False, True)
+						self.logger.debug(out)
+						self.logger.debug(err)
 
 						_, out ,err = self.host_interface.spawn_blocking_subprocess(docker_compose_vars + " docker compose down", False, True) # TODO TEMP
 						self.logger.debug(out)
+						self.logger.debug(err)
 
 					# BREAKDOWN
 					if client.type == Endpoint.Type.HOST:


### PR DESCRIPTION
Support for tcpdump on eth0 and eth1 of the shaper, independent of its software and/or configuration.