### PR TITLE
fix fresh launch error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     volumes:
       - $LOG_PATH_SHAPER:/logs/
     env_file: 
-      - shaper.env
+      - path: shaper.env
+        required: false
     cap_add: 
       - NET_ADMIN
     expose:
@@ -64,7 +65,8 @@ services:
       - $CERTS:/certs:ro
       - $LOG_PATH_SERVER:/logs/
     env_file: 
-      - server.env
+      - path: server.env
+        required: false
     depends_on:
       - sim
     cap_add: 
@@ -86,8 +88,9 @@ services:
       - $DOWNLOAD_PATH_CLIENT:/downloads:delegated
       - $CERTS:/certs:ro
       - $LOG_PATH_CLIENT:/logs/
-    env_file: 
-      client.env
+    env_file:
+      - path: client.env
+        required: false
     depends_on:
       - sim
     cap_add: 

--- a/vegvisir/runner.py
+++ b/vegvisir/runner.py
@@ -209,7 +209,9 @@ class Experiment:
 							+ containers
 						)
 						# self.host_interface.spawn_parallel_subprocess(cmd, False, True)
-						self.host_interface.spawn_blocking_subprocess(cmd, False, True) # TODO Test out if this truly fixes the RNETLINK error? This call might be too slow
+						_, out, err = self.host_interface.spawn_blocking_subprocess(cmd, False, True) # TODO Test out if this truly fixes the RNETLINK error? This call might be too slow
+
+						self.logger.debug(f"Started sim and server | STDOUT [{out}] | STDERR [{chr(10) if err.find(chr(10)) >= 0 else ''}{err}{chr(10) if err.find(chr(10)) >= 0 else ''}]") # chr(10) => '\n'
 						
 						# Host applications require some packet rerouting to be able to reach docker containers
 						if self.configuration.client_endpoints[client_config["name"]].type == Endpoint.Type.HOST:


### PR DESCRIPTION
Error: generic vegvisir error when launching a test with a local application after a fresh clone 
Same as #15 

Cause: client.env does not exist, is only generated by vegvisir at a later point and IF the client is of type docker

Known workaround: run a docker experiment first

Fixes by this PR:
— docker-compose: make environment files optional
— runner.py: add debug log, so the cause for this error is actually logged

The setup should still be able to run without vegvisir specific env var files. If the application (client, sim, server) lacks critical information to start an experiment, it should provide an error.